### PR TITLE
PartyBattlerShouldAvoidHazards fix

### DIFF
--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2408,9 +2408,19 @@ static bool32 AnyUsefulStatIsRaised(u8 battler)
     return FALSE;
 }
 
+struct Pokemon *GetPartyBattlerPartyData(u8 battlerId, u8 switchBattler)
+{
+    struct Pokemon *mon;
+    if (GetBattlerSide(battlerId) == B_SIDE_PLAYER)
+        mon = &gPlayerParty[switchBattler];
+    else
+        mon = &gEnemyParty[switchBattler];
+    return mon;
+}
+
 static bool32 PartyBattlerShouldAvoidHazards(u8 currBattler, u8 switchBattler)
 {
-    struct Pokemon *mon = GetBattlerPartyData(switchBattler);
+    struct Pokemon *mon = GetPartyBattlerPartyData(currBattler, switchBattler);
     u16 ability = GetMonAbility(mon);   // we know our own party data
     u16 holdEffect = GetBattlerHoldEffect(GetMonData(mon, MON_DATA_HELD_ITEM), TRUE);
     u32 flags = gSideStatuses[GetBattlerSide(currBattler)] & (SIDE_STATUS_SPIKES | SIDE_STATUS_STEALTH_ROCK | SIDE_STATUS_STICKY_WEB | SIDE_STATUS_TOXIC_SPIKES);


### PR DESCRIPTION
PartyBattlerShouldAvoidHazards was using GetBattlerPartyData with an index party instead of a battlerId.
This caused GetBattlerPartyData to load wrong data. In my tests I had this function returning value like 0x207XXXX. I don't even know what kind of consequences it can have.
But it could potentially loads data from the PC, the flag area, etc.
PartyBattlerShouldAvoidHazards would then use this value as a pointer to a party data. So, when read, this "party data" would be turned into a bad egg, which means setting two bits in the RAM to 1.
Since this "party data" isn't actually, in most cases, what it should be, it means values are randomly set in the ram. It could create bad eggs, set flags, etc etc

Still needs review though