### PR TITLE
IS_BOX_MON_BAD_EGG(boxMon) instead of setting bits

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3347,6 +3347,8 @@ u32 GetMonData(struct Pokemon *mon, s32 field, u8* data)
     return ret;
 }
 
+#define IS_BOX_MON_BAD_EGG(boxMon) (CalculateBoxMonChecksum(boxMon) != boxMon->checksum)
+
 u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
 {
     s32 i;
@@ -3365,13 +3367,6 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         substruct3 = &(GetSubstruct(boxMon, boxMon->personality, 3)->type3);
 
         DecryptBoxMon(boxMon);
-
-        if (CalculateBoxMonChecksum(boxMon) != boxMon->checksum)
-        {
-            boxMon->isBadEgg = 1;
-            boxMon->isEgg = 1;
-            substruct3->isEgg = 1;
-        }
     }
 
     switch (field)
@@ -3384,7 +3379,7 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         break;
     case MON_DATA_NICKNAME:
     {
-        if (boxMon->isBadEgg)
+        if (IS_BOX_MON_BAD_EGG(boxMon))
         {
             for (retVal = 0;
                 retVal < POKEMON_NAME_LENGTH && gText_BadEgg[retVal] != EOS;
@@ -3424,13 +3419,13 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         retVal = boxMon->language;
         break;
     case MON_DATA_SANITY_IS_BAD_EGG:
-        retVal = boxMon->isBadEgg;
+        retVal = IS_BOX_MON_BAD_EGG(boxMon);
         break;
     case MON_DATA_SANITY_HAS_SPECIES:
         retVal = boxMon->hasSpecies;
         break;
     case MON_DATA_SANITY_IS_EGG:
-        retVal = boxMon->isEgg;
+        retVal = boxMon->isEgg | IS_BOX_MON_BAD_EGG(boxMon);
         break;
     case MON_DATA_OT_NAME:
     {
@@ -3455,7 +3450,7 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         retVal = boxMon->unknown;
         break;
     case MON_DATA_SPECIES:
-        retVal = boxMon->isBadEgg ? SPECIES_EGG : substruct0->species;
+        retVal = IS_BOX_MON_BAD_EGG(boxMon) ? SPECIES_EGG : substruct0->species;
         break;
     case MON_DATA_HELD_ITEM:
         retVal = substruct0->heldItem;
@@ -3554,7 +3549,7 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         retVal = substruct3->spDefenseIV;
         break;
     case MON_DATA_IS_EGG:
-        retVal = substruct3->isEgg;
+        retVal = substruct3->isEgg | IS_BOX_MON_BAD_EGG(boxMon);
         break;
     case MON_DATA_ABILITY_NUM:
         retVal = substruct3->abilityNum;
@@ -3618,14 +3613,14 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         break;
     case MON_DATA_SPECIES2:
         retVal = substruct0->species;
-        if (substruct0->species && (substruct3->isEgg || boxMon->isBadEgg))
+        if (substruct0->species && (substruct3->isEgg || IS_BOX_MON_BAD_EGG(boxMon)))
             retVal = SPECIES_EGG;
         break;
     case MON_DATA_IVS:
         retVal = substruct3->hpIV | (substruct3->attackIV << 5) | (substruct3->defenseIV << 10) | (substruct3->speedIV << 15) | (substruct3->spAttackIV << 20) | (substruct3->spDefenseIV << 25);
         break;
     case MON_DATA_KNOWN_MOVES:
-        if (substruct0->species && !substruct3->isEgg)
+        if (substruct0->species && !IS_BOX_MON_BAD_EGG(boxMon))
         {
             u16 *moves = (u16 *)data;
             s32 i = 0;
@@ -3644,7 +3639,7 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         break;
     case MON_DATA_RIBBON_COUNT:
         retVal = 0;
-        if (substruct0->species && !substruct3->isEgg)
+        if (substruct0->species && !IS_BOX_MON_BAD_EGG(boxMon))
         {
             retVal += substruct3->coolRibbon;
             retVal += substruct3->beautyRibbon;
@@ -3667,7 +3662,7 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
         break;
     case MON_DATA_RIBBONS:
         retVal = 0;
-        if (substruct0->species && !substruct3->isEgg)
+        if (substruct0->species && !IS_BOX_MON_BAD_EGG(boxMon))
         {
             retVal = substruct3->championRibbon
                 | (substruct3->coolRibbon << 1)
@@ -3764,11 +3759,8 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
 
         DecryptBoxMon(boxMon);
 
-        if (CalculateBoxMonChecksum(boxMon) != boxMon->checksum)
+        if (IS_BOX_MON_BAD_EGG(boxMon))
         {
-            boxMon->isBadEgg = 1;
-            boxMon->isEgg = 1;
-            substruct3->isEgg = 1;
             EncryptBoxMon(boxMon);
             return;
         }
@@ -3792,8 +3784,7 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
     case MON_DATA_LANGUAGE:
         SET8(boxMon->language);
         break;
-    case MON_DATA_SANITY_IS_BAD_EGG:
-        SET8(boxMon->isBadEgg);
+    case MON_DATA_SANITY_IS_BAD_EGG: // This shouldn't do anything now. Bad eggs are evaluated at runtime
         break;
     case MON_DATA_SANITY_HAS_SPECIES:
         SET8(boxMon->hasSpecies);


### PR DESCRIPTION
Safety measure to avoid RAM corruption, see https://github.com/rh-hideout/pokeemerald-expansion/pull/1908

As seen in the PR above, the engine was trying to read data unrelated to pokemon in the RAM. Or was sometimes trying to read un-aligned pokemon data. This resulted in Get/SetBoxMonData to think that this area was a corrupted mon; it would thus set the badEgg bit, and the isEgg bits (2 of them), corrupting RAM or other area. I've seen this process lead to bad eggs creation, bugs in the battle engine, possibly many other things like setting unwanted flags and other niceties.
TLDR; the bad-egg safety measure resulted in creating problem because of a wrong area read.

What this new PR does is checking if a mon is a bad egg at runtime, instead of setting the bits discussed above. Now, a corrupted pokémon will still be considered corrupted, but if the engine reads in the wrong area, it won't corrupt data itself.